### PR TITLE
Updated highlightjs-line-numbers to 2.7.0

### DIFF
--- a/views/layout.dt
+++ b/views/layout.dt
@@ -47,7 +47,7 @@ html(lang="en")
         block scripts
         link(rel="stylesheet", href="/style/materialdark.css")
         script(src="/highlightjs/highlight.pack.js")
-        script(src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.5.0/highlightjs-line-numbers.min.js")
+        script(src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.7.0/highlightjs-line-numbers.min.js")
         script.
             hljs.initHighlightingOnLoad();
             hljs.initLineNumbersOnLoad();


### PR DESCRIPTION
Closes #107 