### PR TITLE
Sanitise the HTML in markdown

### DIFF
--- a/views/paste.dt
+++ b/views/paste.dt
@@ -26,7 +26,7 @@ block body
                         - if (p.language == "Markdown" || p.language == "GitHub Flavored Markdown")
                             .markdown-rendered
                                 - import commonmarkd;
-                                |!= convertMarkdownToHTML(p.code, MarkdownFlag.tablesExtension)
+                                |!= convertMarkdownToHTML(p.code, MarkdownFlag.noHTML)
                                 textarea.hidden=p.code
                         - else
                             textarea=p.code

--- a/views/paste.dt
+++ b/views/paste.dt
@@ -26,7 +26,7 @@ block body
                         - if (p.language == "Markdown" || p.language == "GitHub Flavored Markdown")
                             .markdown-rendered
                                 - import commonmarkd;
-                                |!= convertMarkdownToHTML(p.code, MarkdownFlag.noHTML)
+                                |!= convertMarkdownToHTML(p.code, MarkdownFlag.noHTML, MarkdownFlag.tablesExtension)
                                 textarea.hidden=p.code
                         - else
                             textarea=p.code


### PR DESCRIPTION
#295 - Leaves the potential for malicious activities as rendering HTML is allowed. Simple option in this can prevent this from happening. 