### PR TITLE
Fix Typo in Time Endpoint Documentation

### DIFF
--- a/public/docs/time.md
+++ b/public/docs/time.md
@@ -1,6 +1,6 @@
 ## time
 
-endpoint for useful time oprations.
+endpoint for useful time operations.
 
 ### expires in to a unix timestamp
 


### PR DESCRIPTION
Changes

`line 3`
Before:
> ```md
> endpoint for useful time oprations.
> ```

After:
> ```md
> endpoint for useful time operations.
> ```
